### PR TITLE
Tests and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*~
+_build
+_tests
+*.native
+*.byte

--- a/.merlin
+++ b/.merlin
@@ -1,0 +1,4 @@
+PKG alcotest
+
+S src
+B _build/**

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,21 @@
+.PHONY: build test install uninstall doc gh-pages clean
+
 LIB=ISO8601
 LIB_FILES=$(addprefix $(LIB)., a cmxa cma cmi)
 VERSION=0.2.4
+
+OCAMLBUILD=ocamlbuild -use-ocamlfind -classic-display
 
 .INTERMEDIATE: $(LIB).odocl
 
 build: $(LIB_FILES)
 
 $(LIB_FILES):
-	ocamlbuild -I src $@
+	$(OCAMLBUILD) $@
+
+test:
+	$(OCAMLBUILD) test.native
+	./test.native
 
 install: META $(LIB_FILES)
 	ocamlfind install $(LIB) META $(addprefix _build/src/, $(LIB_FILES))
@@ -19,7 +27,7 @@ $(LIB).odocl:
 	echo 'ISO8601' > $@
 
 doc: $(LIB).odocl
-	ocamlbuild -I src $(LIB).docdir/index.html
+	$(OCAMLBUILD) $(LIB).docdir/index.html
 
 gh-pages: doc
 	commitmsg="Documentation for $(VERSION) version." \
@@ -28,7 +36,4 @@ gh-pages: doc
 	ghpup
 
 clean:
-	ocamlbuild -clean
-
-clean:
-	ocamlbuild -clean
+	$(OCAMLBUILD) -clean

--- a/_tags
+++ b/_tags
@@ -1,0 +1,2 @@
+"src": include
+"test": include

--- a/opam
+++ b/opam
@@ -20,10 +20,17 @@ bug-reports: "https://github.com/sagotch/ISO8601.ml/issues"
 
 build-doc: [ make "doc" ]
 
+build-test: [ make "test" ]
+
 build: [ make "build" ]
 
 install: [ make "install" ]
 
 remove: [ "ocamlfind" "remove" "ISO8601" ]
 
-depends: [ "ocamlfind" ]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "base-unix"
+  "alcotest" {test}
+]

--- a/src/ISO8601.ml
+++ b/src/ISO8601.ml
@@ -43,7 +43,6 @@ module Permissive = struct
     let datetime ?(reqtime=true) s =
       datetime_lex ~reqtime:reqtime (Lexing.from_string s)
 
-    (* FIXME: possible loss of precision. *)
     let pp_format fmt format x tz =
 
       let open Unix in
@@ -56,7 +55,9 @@ module Permissive = struct
         | Some tz -> gmtime (x +. tz)
       in
 
-      let print_tz_hours fmt tz = fprintf fmt "%0+3.0f" (tz /. 3600.) in
+      let print_tz_hours fmt tz =
+        fprintf fmt "%0+3d" (Pervasives.truncate (tz /. 3600.))
+      in
 
       let print_tz_minutes fmt tz =
         fprintf fmt "%02.0f" (mod_float (abs_float (tz /. 60.)) 60.0)

--- a/src/ISO8601.ml
+++ b/src/ISO8601.ml
@@ -13,9 +13,17 @@ module Permissive = struct
     let datetime_tz_lex ?(reqtime=true) lexbuf =
       let d = date_lex lexbuf in
       match Lexer.delim lexbuf with
-      | None -> if reqtime then assert false else (d, None)
-      | Some _ -> let (t, tz) = time_tz_lex lexbuf in
-                  (d +. t, tz)
+      | None ->
+        (* TODO: this should be a real exception *)
+        if reqtime then assert false else (d, None)
+      | Some _ ->
+        let (t, tz) = time_tz_lex lexbuf in
+        match tz with
+        | None -> (d +. t, tz)
+        | Some tz ->
+          let t = d +. t in
+          let offt = fst (Unix.mktime (Unix.gmtime t)) in
+          (t -. (offt -. t), Some tz)
 
     let time_lex lexbuf =
       fst (time_tz_lex lexbuf)

--- a/src/ISO8601.mli
+++ b/src/ISO8601.mli
@@ -53,8 +53,6 @@ module Permissive : sig
         to [fmt], and conversion specifications, each of which causes
         conversion and printing of (a part of) [x] or [tz].
 
-        {b If you do not want to use a timezone, set it to 0.}
-
         Conversion specifications have the form [%X], where X can be:
 
         - [Y]: Year
@@ -63,26 +61,32 @@ module Permissive : sig
         - [h]: Hours
         - [m]: Minutes
         - [s]: Seconds
-        - [Z]: Hours of [tz] offset (with its sign)
-        - [z]: Minutes of [tz] offset (without sign)
+        - [Z]: Hours and minutes of [tz] offset (with sign), colon separated,
+               'Z' if [tz] offset is 0; if [tz] is None, print nothing
+        - [z]: Hours and minutes of [tz] offset (with sign), without colon,
+               'Z' if [tz] offset is 0; if [tz] is None, print nothing
         - [%]: The '%' character
 
      *)
-    val pp_format : Format.formatter -> string -> float -> float -> unit
+    val pp_format : Format.formatter -> string -> float -> float option -> unit
 
     (** "%Y-%M-%D" format. *)
+    val pp_date_utc : Format.formatter -> float -> unit
     val pp_date : Format.formatter -> float -> unit
     val string_of_date : float -> string
 
     (** "%Y%M%D" format. *)
+    val pp_date_basic_utc : Format.formatter -> float -> unit
     val pp_date_basic : Format.formatter -> float -> unit
     val string_of_date_basic : float -> string
 
     (** "%h:%m:%s" format. *)
+    val pp_time_utc : Format.formatter -> float -> unit
     val pp_time : Format.formatter -> float -> unit
     val string_of_time : float -> string
 
     (** "%h%m%s" format. *)
+    val pp_time_basic_utc : Format.formatter -> float -> unit
     val pp_time_basic : Format.formatter -> float -> unit
     val string_of_time_basic : float -> string
 
@@ -91,14 +95,15 @@ module Permissive : sig
     val string_of_datetime : float -> string
 
     (** "%Y%M%DT%h%m%s" format. *)
+    val pp_datetime_basic_utc : Format.formatter -> float -> unit
     val pp_datetime_basic : Format.formatter -> float -> unit
     val string_of_datetime_basic : float -> string
 
-    (** "%Y-%M-%DT%h:%m:%s%Z:%z" format. *)
+    (** "%Y-%M-%DT%h:%m:%s%Z" format. *)
     val pp_datetimezone : Format.formatter -> (float * float) -> unit
     val string_of_datetimezone : (float * float) -> string
 
-    (** "%Y%M%DT%h%m%s%Z%z" format. *)
+    (** "%Y%M%DT%h%m%s%z" format. *)
     val pp_datetimezone_basic : Format.formatter -> (float * float) -> unit
     val string_of_datetimezone_basic : (float * float) -> string
 

--- a/src/ISO8601_lexer.mll
+++ b/src/ISO8601_lexer.mll
@@ -3,19 +3,17 @@
 
   (* Date helpers *)
   let mkdate y m d =
-    let (t, tm) = Unix.mktime {
-                      Unix.tm_sec = 0 ;
-                      tm_min = 0 ;
-                      tm_hour = 0 ;
-                      tm_mday = d ;
-                      tm_mon = m - 1 ;
-                      tm_year = y - 1900 ;
-                      tm_wday = -1 ;
-                      tm_yday = -1 ;
-                      tm_isdst = false ; } in
-    let offset = fst (Unix.mktime (Unix.gmtime 0. )) in
-    (** FIXME: Ensure the daylight saving time correction is right. *)
-    t -. offset +. (if tm.Unix.tm_isdst then 3600. else 0.)
+    fst (Unix.mktime {
+      Unix.tm_sec = 0 ;
+      tm_min = 0 ;
+      tm_hour = 0 ;
+      tm_mday = d ;
+      tm_mon = m - 1 ;
+      tm_year = y - 1900 ;
+      tm_wday = -1 ;
+      tm_yday = -1 ;
+      tm_isdst = false ;
+    })
 
   let ymd y m d = mkdate (int y) (int m) (int d)
   let ym y m = mkdate (int y) (int m) 1

--- a/test/_tags
+++ b/test/_tags
@@ -1,0 +1,1 @@
+<*.*>: package(alcotest)

--- a/test/test.ml
+++ b/test/test.ml
@@ -70,7 +70,7 @@ let fixed_time_tests f = [
   "fixed_unix_time_nowish_ist", `Quick,
   f 1451407335. 19800.    "2015-12-29T22:12:15+05:30";
   "fixed_unix_time_nowish_vet", `Quick,
-  f 1451407335. (-16200.) "2015-12-29T22:12:15-04:30";
+  f 1451407335. (-16200.) "2015-12-29T12:12:15-04:30";
 ]
 
 let str_tm year month day hour minute second tz =

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,0 +1,157 @@
+(*
+ * Copyright (c) 2015 David Sheets <sheets@alum.mit.edu>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+module Tm_struct : Alcotest.TESTABLE with type t = Unix.tm = struct
+  type t = Unix.tm
+
+  let pp fmt tm =
+    let open Unix in
+    let s = Printf.sprintf "%d-%02d-%02dT%02d:%02d:%02d"
+        (1900+tm.tm_year) (tm.tm_mon+1) tm.tm_mday
+        tm.tm_hour tm.tm_min tm.tm_sec
+    in
+    Format.pp_print_string fmt s
+
+  let equal a b =
+    Unix.(a.tm_sec = b.tm_sec
+          && a.tm_min = b.tm_min
+          && a.tm_hour = b.tm_hour
+          && a.tm_mday = b.tm_mday
+          && a.tm_mon = b.tm_mon
+          && a.tm_year = b.tm_year)
+end
+
+let tm_struct = (module Tm_struct : Alcotest.TESTABLE with type t = Unix.tm)
+
+type hemi = Neg | Pos
+type tz = Local | Z | Tz of hemi * int * int
+
+let time_tests f = [
+  "before_1900",      `Quick, f 1861  9  1 8 0 0 Local;
+  "before_epoch",     `Quick, f 1969  1  1 0 0 1 Local;
+  "nowish",           `Quick, f 2015 12 27 0 0 1 Local;
+  "before_1900_z",    `Quick, f 1861  9  1 8 0 0 Z;
+  "before_epoch_z",   `Quick, f 1969  1  1 0 0 1 Z;
+  "nowish_z",         `Quick, f 2015 12 27 0 0 1 Z;
+  "before_1900_est",  `Quick, f 1861  9  1 8 0 0 (Tz (Neg,5,0));
+  "before_epoch_est", `Quick, f 1969  1  1 0 0 1 (Tz (Neg,5,0));
+  "nowish_est",       `Quick, f 2015 12 27 0 0 1 (Tz (Neg,5,0));
+]
+
+let str_tm year month day hour minute second tz =
+  let str = Printf.sprintf "%d-%02d-%02dT%02d:%02d:%02d%s"
+      year month day hour minute second
+      (match tz with
+       | Local -> ""
+       | Z -> "Z"
+       | Tz (Neg, hr, mn) -> Printf.sprintf "-%02d:%02d" hr mn
+       | Tz (Pos, hr, mn) -> Printf.sprintf "+%02d:%02d" hr mn
+      )
+  in
+  let tm = Unix.({
+    tm_sec  = second;
+    tm_min  = minute;
+    tm_hour = hour;
+    tm_mday = day;
+    tm_mon  = month - 1;
+    tm_year = year - 1900;
+    tm_wday = 0;
+    tm_yday = 0;
+    tm_isdst = false;
+  }) in
+  let t,  _ = Unix.mktime tm in
+  let t', _ = Unix.mktime (Unix.gmtime t) in
+  let local_unix_time = t -. (t' -. t) in
+  let tm = match tz with
+    | Local -> tm
+    | Z -> snd Unix.(mktime (gmtime local_unix_time))
+    | Tz (Neg, hr, mn) ->
+      let t = local_unix_time +. (float_of_int ((hr * 3600) + (mn * 60))) in
+      snd Unix.(mktime (gmtime t))
+    | Tz (Pos, hr, mn) ->
+      let t = local_unix_time -. (float_of_int ((hr * 3600) + (mn * 60))) in
+      snd Unix.(mktime (gmtime t))
+  in
+  (str, tm)
+
+let erange = Unix.Unix_error (Unix.ERANGE, "mktime", "")
+
+let parse_test year month day hour minute second tz () =
+  if year < 1900
+  then Alcotest.check_raises "< 1900 is ERANGE" erange (fun () ->
+    ignore (ISO8601.Permissive.datetime "1861-01-01T00:00:00Z")
+  )
+  else
+    let str, tm = str_tm year month day hour minute second tz in
+    let parsed = ISO8601.Permissive.datetime str in
+    let output = match tz with
+      | Local    -> Unix.localtime parsed
+      | Z | Tz _ -> Unix.gmtime parsed
+    in
+    Alcotest.(check tm_struct ("parse "^str) tm output)
+
+let parse_tests = time_tests parse_test
+
+let string_of_datetime unix_time = function
+  | Local -> ISO8601.Permissive.string_of_datetime unix_time
+  | Z -> ISO8601.Permissive.string_of_datetimezone (unix_time,0.)
+  | Tz (Neg,hr,mn) ->
+    let tz = float_of_int (- (hr * 3600 + mn * 60)) in
+    ISO8601.Permissive.string_of_datetimezone (unix_time, tz)
+  | Tz (Pos,hr,mn) ->
+    let tz = float_of_int (hr * 3600 + mn * 60) in
+    ISO8601.Permissive.string_of_datetimezone (unix_time, tz)
+
+let print_test year month day hour minute second tz () =
+  (* We use Unix.mktime to find the epoch time but with year < 1900 it
+     will error with ERANGE. *)
+  if year < 1900
+  then ()
+  else
+    let str, tm = str_tm year month day hour minute second tz in
+    let unix_time, _ = Unix.mktime tm in
+    let unix_time = match tz with
+      | Local -> unix_time
+      | Z | Tz _ ->
+        let offt, _ = Unix.mktime (Unix.gmtime unix_time) in
+        unix_time -. (offt -. unix_time)
+    in
+    let output = string_of_datetime unix_time tz in
+    Alcotest.(check string ("print "^str) str output)
+
+let print_tests = time_tests print_test
+
+let rt_test year month day hour minute second tz () =
+  if year < 1900
+  then Alcotest.check_raises "< 1900 is ERANGE" erange (fun () ->
+    ignore (ISO8601.Permissive.datetime "1861-01-01T00:00:00")
+  )
+  else
+    let str, _ = str_tm year month day hour minute second tz in
+    let output = string_of_datetime (ISO8601.Permissive.datetime str) tz in
+    Alcotest.(check string ("roundtrip "^str) str output)
+
+let rt_tests = time_tests rt_test
+
+let suites = [
+  "parse", parse_tests;
+  "print", print_tests;
+  "rt",    rt_tests;
+]
+
+;;
+Alcotest.run "ISO8601" suites


### PR DESCRIPTION
This patchset introduces a test suite using [alcotest](https://github.com/mirage/alcotest) which covers parsing, printing, and roundtripping (composed parsing/printing and printing/parsing).

Bug fixes include:

 - A correct UTC UNIX time is now always returned from parsing instead of a timezone-offset UNIX time.
 - Timezone offsets are now calculated with respect to the time in question rather than the UNIX epoch. The old behavior was applying the local timezone's offset *in 1970* to all times in the local timezone. This caused problems in timezones with historical deviations in 1970. For instance, in 1970 in Great Britain, the government tried a British Standard Time experiment which kept the country on DST all year. This experiment ended in 1971 but its effects were being applied to times which do not fall in the duration of the experiment. This is because historical timezone data is available from the tzinfo database that the OS contains and uses to do timezone conversions.
 - When no timezone is specified, the local timezone settings are used as specified in ISO 8601/RFC 3339.
 - Fixed a printing bug with half-hour and other fractional timezones (e.g. in India and Venezuela) which would cause the printed timezone offset to be 1 hour off due to using low-precision floating point printing instead of float truncation.

Features include:

 - If the timezone offset is 0, Z is printed instead of `+00:00` as allowed by the standard.
 - Printing functions that do not include timezone parameters or timezone output now provide the local time and `*_utc` variants have been added to print the UTC timezone-less dates and times.