### PR TITLE
Fix opam dependencies to include `ocamlbuild`

### DIFF
--- a/opam
+++ b/opam
@@ -26,4 +26,7 @@ install: [ make "install" ]
 
 remove: [ "ocamlfind" "remove" "ISO8601" ]
 
-depends: [ "ocamlfind" ]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]


### PR DESCRIPTION
If you look at the [commit history](https://github.com/ocaml/opam-repository/commits/master/packages/ISO8601) of ISO8601 packages in the opam repository, you see that Fabrice fixed the dependencies for all releases upto 0.2.4, but that 0.2.5 was released with broken dependencies again. Let's make sure this does not happen anymore.