### PR TITLE
migrate build to jbuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+_build
+.merlin
+*.install

--- a/ISO8601.opam
+++ b/ISO8601.opam
@@ -22,11 +22,7 @@ build-doc: [ make "doc" ]
 
 build: [ make "build" ]
 
-install: [ make "install" ]
-
-remove: [ "ocamlfind" "remove" "ISO8601" ]
-
 depends: [
-  "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "jbuilder" {build}
+  "base-unix"
 ]

--- a/META
+++ b/META
@@ -1,6 +1,0 @@
-name ="ISO8601"
-version ="0.2.5"
-description ="ISO 8601 and RFC 3339 parsing."
-archive(byte) ="ISO8601.cma"
-archive(native) ="ISO8601.cmxa"
-requires = "unix"

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,16 @@
-LIB=ISO8601
-LIB_FILES=$(addprefix $(LIB)., a cmxa cma cmi)
-VERSION=0.2.5
 
-.INTERMEDIATE: $(LIB).odocl
+build:
+	jbuilder build @install
 
-build: $(LIB_FILES)
-
-$(LIB_FILES):
-	ocamlbuild -I src $@
-
-install: META $(LIB_FILES)
-	ocamlfind install $(LIB) META $(addprefix _build/src/, $(LIB_FILES))
-
-uninstall:
-	ocamlfind remove $(LIB)
-
-$(LIB).odocl:
-	echo 'ISO8601' > $@
-
-doc: $(LIB).odocl
-	ocamlbuild -I src $(LIB).docdir/index.html
+doc:
+	jbuilder build @doc
 
 gh-pages: doc
 	commitmsg="Documentation for $(VERSION) version." \
-	docdir="$(LIB).docdir" \
+	docdir="_build/default/_doc/_html/" \
 	upstream="origin" \
 	ghpup
 
 clean:
-	ocamlbuild -clean
+	jbuilder clean
 
-clean:
-	ocamlbuild -clean

--- a/src/ISO8601_lexer.mll
+++ b/src/ISO8601_lexer.mll
@@ -66,13 +66,13 @@ rule date = parse
   { ymd y m d}
 
 (* YYYYWww / YYYY-Www *)
-| (year as y) 'W' (week as w)
-| (year as y) "-W" (week as w)
+| (year as _y) 'W' (week as _w)
+| (year as _y) "-W" (week as _w)
   { assert false }
 
 (* YYYYWwwD / YYYY-Www-D *)
-| (year as y) 'W' (week as w) (week_day as d)
-| (year as y) '-' 'W' (week as w) '-' (week_day as d)
+| (year as _y) 'W' (week as _w) (week_day as _d)
+| (year as _y) '-' 'W' (week as _w) '-' (week_day as _d)
   { assert false }
 
 (* YYYYDDD / YYYY-DDD *)

--- a/src/jbuild
+++ b/src/jbuild
@@ -1,0 +1,8 @@
+
+(library
+  ((name ISO8601)
+   (public_name ISO8601)
+   (wrapped true)
+   (libraries (unix))))
+
+(ocamllex (ISO8601_lexer))


### PR DESCRIPTION
This should also solve #10 as jbuilder automatically installs .cmx files.